### PR TITLE
Fix bugs in scheduler.py and MLP.py

### DIFF
--- a/MLP/model/MLP.py
+++ b/MLP/model/MLP.py
@@ -22,7 +22,7 @@ class MLP(nn.Module):
 class PreNormMLP(nn.Module):
     def __init__(self, depth=4, width=100, input_size=28*28, output_size=10, **kwargs):
         super(PreNormMLP, self).__init__()
-        layers = [ext.View(input_size), nn.Linear(input_size, width), ext.Activation(), ext.Norm(width)]
+        layers = [ext.View(input_size), nn.Linear(input_size, width), ext.Activation(width), ext.Norm(width)]
         for index in range(depth-1):
             layers.append(nn.Linear(width, width))
             layers.append(ext.Activation())

--- a/MLP/model/MLP.py
+++ b/MLP/model/MLP.py
@@ -25,7 +25,7 @@ class PreNormMLP(nn.Module):
         layers = [ext.View(input_size), nn.Linear(input_size, width), ext.Activation(width), ext.Norm(width)]
         for index in range(depth-1):
             layers.append(nn.Linear(width, width))
-            layers.append(ext.Activation())
+            layers.append(ext.Activation(width))
             layers.append(ext.Norm(width))
         layers.append(nn.Linear(width, output_size))
         self.net = nn.Sequential(*layers)

--- a/extension/scheduler.py
+++ b/extension/scheduler.py
@@ -30,8 +30,7 @@ def setting(optimizer, args, lr_func=None, **kwargs):
     elif lr_method == 'steps':
         scheduler = MultiStepLR(optimizer, args.lr_steps, args.lr_gamma)
     elif lr_method == 'ploy':
-        scheduler = torch.optim.lr_scheduler.LambdaLR(optimizer,
-                                                      lambda _epoch: (1. - _epoch / args.epochs) ** args.lr_gamma)
+        scheduler = LambdaLR(optimizer, lambda _epoch: (1. - _epoch / args.epochs) ** args.lr_gamma)
     elif lr_method == 'auto':
         scheduler = ReduceLROnPlateau(optimizer, factor=args.lr_gamma, patience=args.lr_step, verbose=True)
     elif lr_method == 'exp':


### PR DESCRIPTION
In `scheduler.py` , since everything in `torch.optim.lr_scheduler` has already been imported, there's no need for `scheduler = torch.optim.lr_scheduler.LambdaLR(......) `

Inside the class **PreNormMLP** of  `MLP.py`, it seems that the parameter width is missing in the activation layers...